### PR TITLE
Only set external heading in DriveLocalizers if useExternalHeading is true

### DIFF
--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/MecanumDrive.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/MecanumDrive.kt
@@ -39,7 +39,7 @@ abstract class MecanumDrive @JvmOverloads constructor(
             set(value) {
                 lastWheelPositions = emptyList()
                 lastExtHeading = Double.NaN
-                drive.externalHeading = value.heading
+                if (useExternalHeading) drive.externalHeading = value.heading
                 _poseEstimate = value
             }
         private var lastWheelPositions = emptyList<Double>()

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/SwerveDrive.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/SwerveDrive.kt
@@ -41,7 +41,7 @@ abstract class SwerveDrive @JvmOverloads constructor(
             set(value) {
                 lastWheelPositions = emptyList()
                 lastExtHeading = Double.NaN
-                drive.externalHeading = value.heading
+                if (useExternalHeading) drive.externalHeading = value.heading
                 _poseEstimate = value
             }
         private var lastWheelPositions = emptyList<Double>()

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/TankDrive.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/TankDrive.kt
@@ -37,7 +37,7 @@ abstract class TankDrive constructor(
             set(value) {
                 lastWheelPositions = emptyList()
                 lastExtHeading = Double.NaN
-                drive.externalHeading = value.heading
+                if (useExternalHeading) drive.externalHeading = value.heading
                 _poseEstimate = value
             }
         private var lastWheelPositions = emptyList<Double>()


### PR DESCRIPTION
This is arguably less surprising behavior than doing so - it's been told "please don't touch the drive's external heading", but it's doing it anyway whenever poseEstimate is assigned to. Also, since the externalHeading properties read the rawExternalHeading properties in their setters, not setting externalHeading allows throwing when accessing rawExternalHeading when the localizer is passed `useExternalHeading = false`, which helps detect bugs and prevents requiring have to return a dummy value.