### PR TITLE
Fix the function to match the comment (fixes issue #39)

### DIFF
--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/followers/TrajectoryFollower.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/followers/TrajectoryFollower.kt
@@ -59,7 +59,7 @@ abstract class TrajectoryFollower @JvmOverloads constructor(
     /**
      * Returns true if the current trajectory has finished executing.
      */
-    fun isFollowing() = !executedFinalUpdate && internalIsFollowing()
+    fun isDone() = executedFinalUpdate && !internalIsFollowing()
 
     /**
      * Returns the elapsed time since the last [followTrajectory] call.


### PR DESCRIPTION
Flips the logic for the `isFollowing` function to match the comment above it. Fixes the bug where markers are seldom called at the end of paths. Requires a change to the quickstart repo.