### PR TITLE
Add optional velocity to drive and localizer classes

### DIFF
--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/Drive.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/Drive.kt
@@ -23,11 +23,6 @@ abstract class Drive {
     protected abstract val rawExternalHeading: Double
 
     /**
-     * The heading velocity used to determine pose velocity in some cases
-     */
-    protected val externalHeadingVelocity: Double? = null
-
-    /**
      * The robot's heading in radians as measured by an external sensor (e.g., IMU, gyroscope).
      */
     var externalHeading: Double
@@ -68,4 +63,9 @@ abstract class Drive {
      * Sets the current commanded drive state of the robot. Feedforward is *not* applied to [drivePower].
      */
     abstract fun setDrivePower(drivePower: Pose2d)
+
+    /**
+     * The heading velocity used to determine pose velocity in some cases
+     */
+    open fun getExternalHeadingVelocity(): Double? = null
 }

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/Drive.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/Drive.kt
@@ -23,6 +23,11 @@ abstract class Drive {
     protected abstract val rawExternalHeading: Double
 
     /**
+     * The heading velocity used to determine pose velocity in some cases
+     */
+    protected val externalHeadingVelocity: Double? = null
+
+    /**
      * The robot's heading in radians as measured by an external sensor (e.g., IMU, gyroscope).
      */
     var externalHeading: Double
@@ -39,6 +44,12 @@ abstract class Drive {
         set(value) {
             localizer.poseEstimate = value
         }
+
+    /**
+     *  Current robot pose velocity (optional)
+     */
+    val poseVelocity: Pose2d?
+        get() = localizer.poseVelocity
 
     /**
      * Updates [poseEstimate] with the most recent positional change.

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/MecanumDrive.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/MecanumDrive.kt
@@ -44,6 +44,8 @@ abstract class MecanumDrive @JvmOverloads constructor(
                 if (useExternalHeading) drive.externalHeading = value.heading
                 _poseEstimate = value
             }
+        override var poseVelocity: Pose2d? = null
+            private set
         private var lastWheelPositions = emptyList<Double>()
         private var lastExtHeading = Double.NaN
 
@@ -66,6 +68,18 @@ abstract class MecanumDrive @JvmOverloads constructor(
                     Pose2d(robotPoseDelta.vec(), finalHeadingDelta)
                 )
             }
+
+            val wheelVelocities = drive.getWheelVelocities()
+            val extHeadingVel = drive.externalHeadingVelocity
+            if (wheelVelocities != null) {
+                poseVelocity = MecanumKinematics.wheelToRobotVelocities(
+                        wheelVelocities, drive.trackWidth, drive.wheelBase, drive.lateralMultiplier
+                )
+                if (useExternalHeading && extHeadingVel != null) {
+                    poseVelocity = Pose2d(poseVelocity!!.vec(), extHeadingVel)
+                }
+            }
+
             lastWheelPositions = wheelPositions
             lastExtHeading = extHeading
         }
@@ -98,4 +112,10 @@ abstract class MecanumDrive @JvmOverloads constructor(
      * [setMotorPowers].
      */
     abstract fun getWheelPositions(): List<Double>
+
+    /**
+     * Returns the velocities of the wheels in linear distance units. Positions should exactly match the ordering in
+     * [setMotorPowers].
+     */
+    fun getWheelVelocities(): List<Double>? = null
 }

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/MecanumDrive.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/MecanumDrive.kt
@@ -70,7 +70,7 @@ abstract class MecanumDrive @JvmOverloads constructor(
             }
 
             val wheelVelocities = drive.getWheelVelocities()
-            val extHeadingVel = drive.externalHeadingVelocity
+            val extHeadingVel = drive.getExternalHeadingVelocity()
             if (wheelVelocities != null) {
                 poseVelocity = MecanumKinematics.wheelToRobotVelocities(
                         wheelVelocities, drive.trackWidth, drive.wheelBase, drive.lateralMultiplier
@@ -117,5 +117,5 @@ abstract class MecanumDrive @JvmOverloads constructor(
      * Returns the velocities of the wheels in linear distance units. Positions should exactly match the ordering in
      * [setMotorPowers].
      */
-    fun getWheelVelocities(): List<Double>? = null
+    open fun getWheelVelocities(): List<Double>? = null
 }

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/SwerveDrive.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/SwerveDrive.kt
@@ -43,6 +43,8 @@ abstract class SwerveDrive @JvmOverloads constructor(
                 if (useExternalHeading) drive.externalHeading = value.heading
                 _poseEstimate = value
             }
+        override var poseVelocity: Pose2d? = null
+            private set
         private var lastWheelPositions = emptyList<Double>()
         private var lastExtHeading = Double.NaN
 
@@ -64,6 +66,17 @@ abstract class SwerveDrive @JvmOverloads constructor(
                     Pose2d(robotPoseDelta.vec(), finalHeadingDelta)
                 )
             }
+
+            val wheelVelocities = drive.getWheelVelocities()
+            val extHeadingVel = drive.externalHeadingVelocity
+            if (wheelVelocities != null) {
+                poseVelocity = SwerveKinematics.wheelToRobotVelocities(
+                        wheelVelocities, moduleOrientations, drive.wheelBase, drive.trackWidth)
+                if (useExternalHeading && extHeadingVel != null) {
+                    poseVelocity = Pose2d(poseVelocity!!.vec(), extHeadingVel)
+                }
+            }
+
             lastWheelPositions = wheelPositions
             lastExtHeading = extHeading
         }
@@ -106,6 +119,12 @@ abstract class SwerveDrive @JvmOverloads constructor(
      * [setMotorPowers].
      */
     abstract fun getWheelPositions(): List<Double>
+
+    /**
+     * Returns the velocities of the wheels in linear distance units. Positions should exactly match the ordering in
+     * [setMotorPowers].
+     */
+    fun getWheelVelocities(): List<Double>? = null
 
     /**
      * Returns the current module orientations in radians. Orientations should exactly match the order in

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/SwerveDrive.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/SwerveDrive.kt
@@ -68,7 +68,7 @@ abstract class SwerveDrive @JvmOverloads constructor(
             }
 
             val wheelVelocities = drive.getWheelVelocities()
-            val extHeadingVel = drive.externalHeadingVelocity
+            val extHeadingVel = drive.getExternalHeadingVelocity()
             if (wheelVelocities != null) {
                 poseVelocity = SwerveKinematics.wheelToRobotVelocities(
                         wheelVelocities, moduleOrientations, drive.wheelBase, drive.trackWidth)
@@ -124,7 +124,7 @@ abstract class SwerveDrive @JvmOverloads constructor(
      * Returns the velocities of the wheels in linear distance units. Positions should exactly match the ordering in
      * [setMotorPowers].
      */
-    fun getWheelVelocities(): List<Double>? = null
+    open fun getWheelVelocities(): List<Double>? = null
 
     /**
      * Returns the current module orientations in radians. Orientations should exactly match the order in

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/TankDrive.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/TankDrive.kt
@@ -63,7 +63,7 @@ abstract class TankDrive constructor(
             }
 
             val wheelVelocities = drive.getWheelVelocities()
-            val extHeadingVel = drive.externalHeadingVelocity
+            val extHeadingVel = drive.getExternalHeadingVelocity()
             if (wheelVelocities != null) {
                 poseVelocity = TankKinematics.wheelToRobotVelocities(wheelVelocities, drive.trackWidth)
                 if (useExternalHeading && extHeadingVel != null) {
@@ -105,5 +105,5 @@ abstract class TankDrive constructor(
      * Returns the velocities of the wheels in linear distance units. Positions should exactly match the ordering in
      * [setMotorPowers].
      */
-    fun getWheelVelocities(): List<Double>? = null
+    open fun getWheelVelocities(): List<Double>? = null
 }

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/TankDrive.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/drive/TankDrive.kt
@@ -40,6 +40,8 @@ abstract class TankDrive constructor(
                 if (useExternalHeading) drive.externalHeading = value.heading
                 _poseEstimate = value
             }
+        override var poseVelocity: Pose2d? = null
+            private set
         private var lastWheelPositions = emptyList<Double>()
         private var lastExtHeading = Double.NaN
 
@@ -59,6 +61,16 @@ abstract class TankDrive constructor(
                     Pose2d(robotPoseDelta.vec(), finalHeadingDelta)
                 )
             }
+
+            val wheelVelocities = drive.getWheelVelocities()
+            val extHeadingVel = drive.externalHeadingVelocity
+            if (wheelVelocities != null) {
+                poseVelocity = TankKinematics.wheelToRobotVelocities(wheelVelocities, drive.trackWidth)
+                if (useExternalHeading && extHeadingVel != null) {
+                    poseVelocity = Pose2d(poseVelocity!!.vec(), extHeadingVel)
+                }
+            }
+
             lastWheelPositions = wheelPositions
             lastExtHeading = extHeading
         }
@@ -88,4 +100,10 @@ abstract class TankDrive constructor(
      * [setMotorPowers].
      */
     abstract fun getWheelPositions(): List<Double>
+
+    /**
+     * Returns the velocities of the wheels in linear distance units. Positions should exactly match the ordering in
+     * [setMotorPowers].
+     */
+    fun getWheelVelocities(): List<Double>? = null
 }

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/localization/Localizer.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/localization/Localizer.kt
@@ -13,6 +13,11 @@ interface Localizer {
     var poseEstimate: Pose2d
 
     /**
+     * Current robot pose velocity (optional)
+     */
+    val poseVelocity: Pose2d?
+
+    /**
      * Completes a single localization update.
      */
     fun update()

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/localization/ThreeTrackingWheelLocalizer.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/localization/ThreeTrackingWheelLocalizer.kt
@@ -22,6 +22,8 @@ abstract class ThreeTrackingWheelLocalizer(
             lastWheelPositions = emptyList()
             _poseEstimate = value
         }
+    final override var poseVelocity: Pose2d? = null
+        private set
     private var lastWheelPositions = emptyList<Double>()
 
     private val forwardSolver: DecompositionSolver
@@ -44,22 +46,32 @@ abstract class ThreeTrackingWheelLocalizer(
         require(forwardSolver.isNonSingular) { "The specified configuration cannot support full localization" }
     }
 
+    private fun calculatePoseDelta(wheelDeltas: List<Double>): Pose2d {
+        val rawPoseDelta = forwardSolver.solve(MatrixUtils.createRealMatrix(
+                arrayOf(wheelDeltas.toDoubleArray())
+        ).transpose())
+        return Pose2d(
+                rawPoseDelta.getEntry(0, 0),
+                rawPoseDelta.getEntry(1, 0),
+                rawPoseDelta.getEntry(2, 0)
+        )
+    }
+
     override fun update() {
         val wheelPositions = getWheelPositions()
         if (lastWheelPositions.isNotEmpty()) {
             val wheelDeltas = wheelPositions
                     .zip(lastWheelPositions)
                     .map { it.first - it.second }
-            val rawPoseDelta = forwardSolver.solve(MatrixUtils.createRealMatrix(
-                    arrayOf(wheelDeltas.toDoubleArray())
-            ).transpose())
-            val robotPoseDelta = Pose2d(
-                rawPoseDelta.getEntry(0, 0),
-                rawPoseDelta.getEntry(1, 0),
-                rawPoseDelta.getEntry(2, 0)
-            )
+            val robotPoseDelta = calculatePoseDelta(wheelDeltas)
             _poseEstimate = Kinematics.relativeOdometryUpdate(_poseEstimate, robotPoseDelta)
         }
+
+        val wheelVelocities = getWheelVelocities()
+        if (wheelVelocities != null) {
+            poseVelocity = calculatePoseDelta(wheelVelocities)
+        }
+
         lastWheelPositions = wheelPositions
     }
 
@@ -67,4 +79,9 @@ abstract class ThreeTrackingWheelLocalizer(
      * Returns the positions of the tracking wheels in the desired distance units (not encoder counts!)
      */
     abstract fun getWheelPositions(): List<Double>
+
+    /**
+     * Returns the velocities of the tracking wheels in the desired distance units (not encoder counts!)
+     */
+    fun getWheelVelocities(): List<Double>? = null
 }

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/localization/ThreeTrackingWheelLocalizer.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/localization/ThreeTrackingWheelLocalizer.kt
@@ -22,8 +22,7 @@ abstract class ThreeTrackingWheelLocalizer(
             lastWheelPositions = emptyList()
             _poseEstimate = value
         }
-    final override var poseVelocity: Pose2d? = null
-        private set
+    override var poseVelocity: Pose2d? = null
     private var lastWheelPositions = emptyList<Double>()
 
     private val forwardSolver: DecompositionSolver
@@ -83,5 +82,5 @@ abstract class ThreeTrackingWheelLocalizer(
     /**
      * Returns the velocities of the tracking wheels in the desired distance units (not encoder counts!)
      */
-    fun getWheelVelocities(): List<Double>? = null
+    open fun getWheelVelocities(): List<Double>? = null
 }

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/localization/TwoTrackingWheelLocalizer.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/localization/TwoTrackingWheelLocalizer.kt
@@ -24,8 +24,7 @@ abstract class TwoTrackingWheelLocalizer(
             lastHeading = Double.NaN
             _poseEstimate = value
         }
-    final override var poseVelocity: Pose2d? = null
-        private set
+    override var poseVelocity: Pose2d? = null
     private var lastWheelPositions = emptyList<Double>()
     private var lastHeading = Double.NaN
 
@@ -91,7 +90,7 @@ abstract class TwoTrackingWheelLocalizer(
     /**
      * Returns the velocities of the tracking wheels in the desired distance units (not encoder counts!)
      */
-    fun getWheelVelocities(): List<Double>? = null
+    open fun getWheelVelocities(): List<Double>? = null
 
     /**
      * Returns the heading of the robot (usually from a gyroscope or IMU).
@@ -101,5 +100,5 @@ abstract class TwoTrackingWheelLocalizer(
     /**
      * Returns the heading of the robot (usually from a gyroscope or IMU).
      */
-    fun getHeadingVelocity(): Double? = null
+    open fun getHeadingVelocity(): Double? = null
 }


### PR DESCRIPTION
Along with minor quickstart patches this would allow for full velocity to be used with derivative-on-measurement. Perhaps velocity should not be made required, however I'm not sure how that would work for non-FTC cases where velocity is not as simple to measure.