### PR TITLE
Fix incorrect d output when measuredVelocity is provided

### DIFF
--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/control/PIDFController.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/control/PIDFController.kt
@@ -130,7 +130,7 @@ class PIDFController
             // note: we'd like to refactor this with Kinematics.calculateMotorFeedforward() but kF complicates the
             // determination of the sign of kStatic
             val baseOutput = pid.kP * error + pid.kI * errorSum +
-                pid.kD * (measuredVelocity?.minus(targetVelocity) ?: errorDeriv) +
+                pid.kD * (measuredVelocity?.let { targetVelocity - it } ?: errorDeriv) +
                 kV * targetVelocity + kA * targetAcceleration + kF(measuredPosition, measuredVelocity)
             val output = if (baseOutput epsilonEquals 0.0) 0.0 else baseOutput + sign(baseOutput) * kStatic
 


### PR DESCRIPTION
When `measuredVelocity` is provided, the PID controller applies the velocity feedback incorrectly. This pull request fixes the backwards d term feedback when `measuredVelocity` is provided.