### PR TITLE
Attempt to fix angle error calculations

### DIFF
--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/geometry/Pose2d.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/geometry/Pose2d.kt
@@ -23,7 +23,7 @@ data class Pose2d @JvmOverloads constructor(
         Pose2d(x + other.x, y + other.y, heading + other.heading)
 
     operator fun minus(other: Pose2d) =
-        Pose2d(x - other.x, y - other.y, heading - other.heading)
+        Pose2d(x - other.x, y - other.y, Angle.normDelta(heading - other.heading))
 
     operator fun times(scalar: Double) =
         Pose2d(scalar * x, scalar * y, scalar * heading)

--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/util/Angle.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/util/Angle.kt
@@ -1,6 +1,8 @@
 package com.acmerobotics.roadrunner.util
 
 import kotlin.math.PI
+import kotlin.math.absoluteValue
+import kotlin.math.sign
 
 /**
  * Various utilities for working with angles.
@@ -31,8 +33,8 @@ object Angle {
     fun normDelta(angleDelta: Double): Double {
         var modifiedAngleDelta = norm(angleDelta)
 
-        if (modifiedAngleDelta > PI) {
-            modifiedAngleDelta -= TAU
+        if (modifiedAngleDelta.absoluteValue > PI) {
+            modifiedAngleDelta -= TAU * modifiedAngleDelta.sign
         }
 
         return modifiedAngleDelta


### PR DESCRIPTION
#63 

We have been using your library for our robot! We have really liked it. We are using a tank chassis and found out an error with the Ramsete Follower, it only appeared when we started from 0,0 and went into some target with negative Y coordinate. 

Making a custom Ramsete follower that does the following when caluclating the error solved the issue:
      
        var angleError = targetPose.heading - currentPose.heading

        if(angleError.absoluteValue > PI){
            angleError -= 2 * PI * angleError.sign
        }

        val error = Pose2d(targetPose.x - currentPose.x, targetPose.y - currentPose.y, angleError)

I looked into the implementation of the minus operation for the Pose2d and saw that it simply substracts one angle from the other. Maybe implementing something like we showed could fix it?