### PR TITLE
Make `DualNum` `double[]` constructor public

### DIFF
--- a/core/src/main/kotlin/com/acmerobotics/roadrunner/DualNum.kt
+++ b/core/src/main/kotlin/com/acmerobotics/roadrunner/DualNum.kt
@@ -10,7 +10,7 @@ import kotlin.math.min
  * @param[Param] \(x\)
  * @property[values] \(\left(u, \frac{du}{dx}, \frac{d^2u}{dx^2}, \ldots, \frac{d^{n - 1} u}{dx^{n - 1}} \right)\)
  */
-class DualNum<Param> internal constructor(private val values: DoubleArray) {
+class DualNum<Param> constructor(private val values: DoubleArray) {
     constructor(values: List<Double>) : this(values.toDoubleArray())
 
     companion object {


### PR DESCRIPTION
Hello!

While writing a few extension functions for `DualNum`, I find myself writing this:

```kotlin
val out = DualNum<Param>(DoubleArray(min(this.size(), other.size())).toList())
```

I create a `DoubleArray` to initialize all of its values to zero, but then I have to convert it to a list in order to construct a `DualNum`. This is inefficient, because `DualNum`'s constructor is:

```kotlin
constructor(values: List<Double>) : this(values.toDoubleArray())
```

Essentially, I'm forced to convert an array to a list and back again because the primary constructor is internal. This gets even worse when you look at Kotlin's implementations of these functions:

```kotlin
public fun List<Double>.toDoubleArray(): DoubleArray {
    val result = DoubleArray(size)
    var index = 0
    // Copy each item, one at a time.
    for (element in this)
        result[index++] = element
    return result
}

public fun DoubleArray.toList(): List<Double> {
    val list = ArrayList<Double>(size)
    // Copy each item, one at a time.
    for (item in this) list.add(item)
    return list
}
```

This pull request fixes this by making the primary `DoubleArray` constructor public, to avoid unnecessary copying and conversion.