### PR TITLE
Add link to 4017's Cookbook in resources

### DIFF
--- a/road-runner-docs/site/content/raw-docs/resources.md
+++ b/road-runner-docs/site/content/raw-docs/resources.md
@@ -1,2 +1,3 @@
 * [Mobile Robot Kinematics for FTC](/papers/Mobile_Robot_Kinematics_for_FTC.html)
 * [Quintic Splines for FTC](/papers/Quintic_Splines_for_FTC.html)
+* [The Cookbook's TrajectoryBuilder Reference](https://cookbook.dairy.foundation/roadrunner_10/complete_trajectorybuilder_reference.html)


### PR DESCRIPTION
4017 has an [excellent resource](https://cookbook.dairy.foundation/introduction.html) for FTC, including a list of all the trajectory functions with much more complete explanations than are provided here. Originally I was going to look at adding their examples to the main resource page, but I wasn't sure how to handle the MIT license attribution. That may still be a good idea if you're interested in doing that, but otherwise I think it would be useful to have a link.