### PR TITLE
Add Forward Trajectory Builder

### DIFF
--- a/road-runner/actions/src/main/kotlin/com/acmerobotics/roadrunner/Actions.kt
+++ b/road-runner/actions/src/main/kotlin/com/acmerobotics/roadrunner/Actions.kt
@@ -423,80 +423,80 @@ class TrajectoryActionBuilder private constructor(
 
     @JvmOverloads
     fun forward(
-        distance: Double,
+        ds: Double,
         velConstraintOverride: VelConstraint? = null,
         accelConstraintOverride: AccelConstraint? = null
     ) = TrajectoryActionBuilder(
         this,
         tb.forward(
-            distance, velConstraintOverride, accelConstraintOverride
+            ds, velConstraintOverride, accelConstraintOverride
         ),
         n + 1, lastPoseUnmapped, lastPose, lastTangent, ms, cont
     )
 
     @JvmOverloads
     fun forwardConstantHeading(
-        distance: Double,
+        ds: Double,
         velConstraintOverride: VelConstraint? = null,
         accelConstraintOverride: AccelConstraint? = null
     ) = TrajectoryActionBuilder(
         this,
         tb.forwardConstantHeading(
-            distance, velConstraintOverride, accelConstraintOverride
+            ds, velConstraintOverride, accelConstraintOverride
         ),
         n + 1, lastPoseUnmapped, lastPose, lastTangent, ms, cont
     )
 
     @JvmOverloads
     fun forwardLinearHeading(
-        distance: Double,
+        ds: Double,
         heading: Rotation2d,
         velConstraintOverride: VelConstraint? = null,
         accelConstraintOverride: AccelConstraint? = null
     ) = TrajectoryActionBuilder(
         this,
         tb.forwardLinearHeading(
-            distance, heading, velConstraintOverride, accelConstraintOverride
+            ds, heading, velConstraintOverride, accelConstraintOverride
         ),
         n + 1, lastPoseUnmapped, lastPose, lastTangent, ms, cont
     )
     @JvmOverloads
     fun forwardLinearHeading(
-        distance: Double,
+        ds: Double,
         heading: Double,
         velConstraintOverride: VelConstraint? = null,
         accelConstraintOverride: AccelConstraint? = null
     ) = TrajectoryActionBuilder(
         this,
         tb.forwardLinearHeading(
-            distance, heading, velConstraintOverride, accelConstraintOverride
+            ds, heading, velConstraintOverride, accelConstraintOverride
         ),
         n + 1, lastPoseUnmapped, lastPose, lastTangent, ms, cont
     )
 
     @JvmOverloads
     fun forwardSplineHeading(
-        distance: Double,
+        ds: Double,
         heading: Rotation2d,
         velConstraintOverride: VelConstraint? = null,
         accelConstraintOverride: AccelConstraint? = null
     ) = TrajectoryActionBuilder(
         this,
         tb.forwardSplineHeading(
-            distance, heading, velConstraintOverride, accelConstraintOverride
+            ds, heading, velConstraintOverride, accelConstraintOverride
         ),
         n + 1, lastPoseUnmapped, lastPose, lastTangent, ms, cont
     )
     @JvmOverloads
     fun forwardSplineHeading(
-        distance: Double,
+        ds: Double,
         heading: Double,
         velConstraintOverride: VelConstraint? = null,
         accelConstraintOverride: AccelConstraint? = null
     ) = TrajectoryActionBuilder(
         this,
         tb.forwardSplineHeading(
-            distance, heading, velConstraintOverride, accelConstraintOverride
+            ds, heading, velConstraintOverride, accelConstraintOverride
         ),
         n + 1, lastPoseUnmapped, lastPose, lastTangent, ms, cont
     )

--- a/road-runner/actions/src/main/kotlin/com/acmerobotics/roadrunner/Actions.kt
+++ b/road-runner/actions/src/main/kotlin/com/acmerobotics/roadrunner/Actions.kt
@@ -422,6 +422,86 @@ class TrajectoryActionBuilder private constructor(
         turnTo(Rotation2d.exp(heading), turnConstraintsOverride)
 
     @JvmOverloads
+    fun forward(
+        distance: Double,
+        velConstraintOverride: VelConstraint? = null,
+        accelConstraintOverride: AccelConstraint? = null
+    ) = TrajectoryActionBuilder(
+        this,
+        tb.forward(
+            distance, velConstraintOverride, accelConstraintOverride
+        ),
+        n + 1, lastPoseUnmapped, lastPose, lastTangent, ms, cont
+    )
+
+    @JvmOverloads
+    fun forwardConstantHeading(
+        distance: Double,
+        velConstraintOverride: VelConstraint? = null,
+        accelConstraintOverride: AccelConstraint? = null
+    ) = TrajectoryActionBuilder(
+        this,
+        tb.forwardConstantHeading(
+            distance, velConstraintOverride, accelConstraintOverride
+        ),
+        n + 1, lastPoseUnmapped, lastPose, lastTangent, ms, cont
+    )
+
+    @JvmOverloads
+    fun forwardLinearHeading(
+        distance: Double,
+        heading: Rotation2d,
+        velConstraintOverride: VelConstraint? = null,
+        accelConstraintOverride: AccelConstraint? = null
+    ) = TrajectoryActionBuilder(
+        this,
+        tb.forwardLinearHeading(
+            distance, heading, velConstraintOverride, accelConstraintOverride
+        ),
+        n + 1, lastPoseUnmapped, lastPose, lastTangent, ms, cont
+    )
+    @JvmOverloads
+    fun forwardLinearHeading(
+        distance: Double,
+        heading: Double,
+        velConstraintOverride: VelConstraint? = null,
+        accelConstraintOverride: AccelConstraint? = null
+    ) = TrajectoryActionBuilder(
+        this,
+        tb.forwardLinearHeading(
+            distance, heading, velConstraintOverride, accelConstraintOverride
+        ),
+        n + 1, lastPoseUnmapped, lastPose, lastTangent, ms, cont
+    )
+
+    @JvmOverloads
+    fun forwardSplineHeading(
+        distance: Double,
+        heading: Rotation2d,
+        velConstraintOverride: VelConstraint? = null,
+        accelConstraintOverride: AccelConstraint? = null
+    ) = TrajectoryActionBuilder(
+        this,
+        tb.forwardSplineHeading(
+            distance, heading, velConstraintOverride, accelConstraintOverride
+        ),
+        n + 1, lastPoseUnmapped, lastPose, lastTangent, ms, cont
+    )
+    @JvmOverloads
+    fun forwardSplineHeading(
+        distance: Double,
+        heading: Double,
+        velConstraintOverride: VelConstraint? = null,
+        accelConstraintOverride: AccelConstraint? = null
+    ) = TrajectoryActionBuilder(
+        this,
+        tb.forwardSplineHeading(
+            distance, heading, velConstraintOverride, accelConstraintOverride
+        ),
+        n + 1, lastPoseUnmapped, lastPose, lastTangent, ms, cont
+    )
+
+    @JvmOverloads
     fun lineToX(
         posX: Double,
         velConstraintOverride: VelConstraint? = null,

--- a/road-runner/core/src/main/kotlin/com/acmerobotics/roadrunner/Builders.kt
+++ b/road-runner/core/src/main/kotlin/com/acmerobotics/roadrunner/Builders.kt
@@ -88,18 +88,13 @@ class PositionPathSeqBuilder private constructor(
     }
 
     /**
-     * @usesMathJax
-     *
-     * Adds a line segment that goes forward [distance].
+     * Adds a line segment that goes forward [ds].
      */
-    fun forward(distance: Double): PositionPathSeqBuilder {
+    fun forward(ds: Double): PositionPathSeqBuilder {
         return addSegment(
             Line(
                 nextBeginPos,
-                Vector2d(
-                    nextBeginPos.x + distance * nextBeginTangent.real,
-                    nextBeginPos.y + distance * nextBeginTangent.imag,
-                ),
+                nextBeginPos + nextBeginTangent.vec() * ds,
             ),
         )
     }
@@ -476,32 +471,32 @@ class PathBuilder private constructor(
         }
     )
 
-    fun forward(distance: Double) = copyTangent(
-        positionPathSeqBuilder.forward(distance),
+    fun forward(ds: Double) = copyTangent(
+        positionPathSeqBuilder.forward(ds),
         headingSegments + PosePathSeqBuilder::tangentUntil
     )
 
-    fun forwardConstantHeading(distance: Double) = copy(
-        positionPathSeqBuilder.forward(distance),
+    fun forwardConstantHeading(ds: Double) = copy(
+        positionPathSeqBuilder.forward(ds),
         headingSegments + PosePathSeqBuilder::constantUntil,
         endHeading
     )
 
-    fun forwardLinearHeading(distance: Double, heading: Rotation2d) = copy(
-        positionPathSeqBuilder.forward(distance),
+    fun forwardLinearHeading(ds: Double, heading: Rotation2d) = copy(
+        positionPathSeqBuilder.forward(ds),
         headingSegments + { linearUntil(it, heading) },
         heading
     )
-    fun forwardLinearHeading(distance: Double, heading: Double) =
-        forwardLinearHeading(distance, Rotation2d.exp(heading))
+    fun forwardLinearHeading(ds: Double, heading: Double) =
+        forwardLinearHeading(ds, Rotation2d.exp(heading))
 
-    fun forwardSplineHeading(distance: Double, heading: Rotation2d) = copy(
-        positionPathSeqBuilder.forward(distance),
+    fun forwardSplineHeading(ds: Double, heading: Rotation2d) = copy(
+        positionPathSeqBuilder.forward(ds),
         headingSegments + { splineUntil(it, heading) },
         heading
     )
-    fun forwardSplineHeading(distance: Double, heading: Double) =
-        forwardSplineHeading(distance, Rotation2d.exp(heading))
+    fun forwardSplineHeading(ds: Double, heading: Double) =
+        forwardSplineHeading(ds, Rotation2d.exp(heading))
 
     fun lineToX(posX: Double) = copyTangent(
         positionPathSeqBuilder.lineToX(posX),
@@ -672,53 +667,53 @@ class TrajectoryBuilder private constructor(
 
     @JvmOverloads
     fun forward(
-        distance: Double,
+        ds: Double,
         velConstraintOverride: VelConstraint? = null,
         accelConstraintOverride: AccelConstraint? = null
     ) =
-        add(pathBuilder.forward(distance), velConstraintOverride, accelConstraintOverride)
+        add(pathBuilder.forward(ds), velConstraintOverride, accelConstraintOverride)
 
     @JvmOverloads
     fun forwardConstantHeading(
-        distance: Double,
+        ds: Double,
         velConstraintOverride: VelConstraint? = null,
         accelConstraintOverride: AccelConstraint? = null
     ) =
-        add(pathBuilder.forwardConstantHeading(distance), velConstraintOverride, accelConstraintOverride)
+        add(pathBuilder.forwardConstantHeading(ds), velConstraintOverride, accelConstraintOverride)
 
     @JvmOverloads
     fun forwardLinearHeading(
-        distance: Double,
+        ds: Double,
         heading: Rotation2d,
         velConstraintOverride: VelConstraint? = null,
         accelConstraintOverride: AccelConstraint? = null
     ) =
-        add(pathBuilder.forwardLinearHeading(distance, heading), velConstraintOverride, accelConstraintOverride)
+        add(pathBuilder.forwardLinearHeading(ds, heading), velConstraintOverride, accelConstraintOverride)
     @JvmOverloads
     fun forwardLinearHeading(
-        distance: Double,
+        ds: Double,
         heading: Double,
         velConstraintOverride: VelConstraint? = null,
         accelConstraintOverride: AccelConstraint? = null
     ) =
-        add(pathBuilder.forwardLinearHeading(distance, heading), velConstraintOverride, accelConstraintOverride)
+        add(pathBuilder.forwardLinearHeading(ds, heading), velConstraintOverride, accelConstraintOverride)
 
     @JvmOverloads
     fun forwardSplineHeading(
-        distance: Double,
+        ds: Double,
         heading: Rotation2d,
         velConstraintOverride: VelConstraint? = null,
         accelConstraintOverride: AccelConstraint? = null
     ) =
-        add(pathBuilder.forwardSplineHeading(distance, heading), velConstraintOverride, accelConstraintOverride)
+        add(pathBuilder.forwardSplineHeading(ds, heading), velConstraintOverride, accelConstraintOverride)
     @JvmOverloads
     fun forwardSplineHeading(
-        distance: Double,
+        ds: Double,
         heading: Double,
         velConstraintOverride: VelConstraint? = null,
         accelConstraintOverride: AccelConstraint? = null
     ) =
-        add(pathBuilder.forwardSplineHeading(distance, heading), velConstraintOverride, accelConstraintOverride)
+        add(pathBuilder.forwardSplineHeading(ds, heading), velConstraintOverride, accelConstraintOverride)
 
     @JvmOverloads
     fun lineToX(

--- a/road-runner/core/src/main/kotlin/com/acmerobotics/roadrunner/Builders.kt
+++ b/road-runner/core/src/main/kotlin/com/acmerobotics/roadrunner/Builders.kt
@@ -492,14 +492,16 @@ class PathBuilder private constructor(
         headingSegments + { linearUntil(it, heading) },
         heading
     )
-    fun forwardLinearHeading(distance: Double, heading: Double) = forwardLinearHeading(distance, Rotation2d.exp(heading))
+    fun forwardLinearHeading(distance: Double, heading: Double) =
+        forwardLinearHeading(distance, Rotation2d.exp(heading))
 
     fun forwardSplineHeading(distance: Double, heading: Rotation2d) = copy(
         positionPathSeqBuilder.forward(distance),
         headingSegments + { splineUntil(it, heading) },
         heading
     )
-    fun forwardSplineHeading(distance: Double, heading: Double) = forwardSplineHeading(distance, Rotation2d.exp(heading))
+    fun forwardSplineHeading(distance: Double, heading: Double) =
+        forwardSplineHeading(distance, Rotation2d.exp(heading))
 
     fun lineToX(posX: Double) = copyTangent(
         positionPathSeqBuilder.lineToX(posX),
@@ -716,8 +718,7 @@ class TrajectoryBuilder private constructor(
         velConstraintOverride: VelConstraint? = null,
         accelConstraintOverride: AccelConstraint? = null
     ) =
-        add(pathBuilder.forwardSplineHeading(distance, heading), velConstraintOverride, accelConstraintOverride
-    )
+        add(pathBuilder.forwardSplineHeading(distance, heading), velConstraintOverride, accelConstraintOverride)
 
     @JvmOverloads
     fun lineToX(

--- a/road-runner/core/src/test/kotlin/com/acmerobotics/roadrunner/BuildersTest.kt
+++ b/road-runner/core/src/test/kotlin/com/acmerobotics/roadrunner/BuildersTest.kt
@@ -139,18 +139,18 @@ fun chartSpline(q: QuinticSpline1d): XYChart {
                     val beginPos = Vector2d(r.nextDouble(), r.nextDouble())
                     val beginTangent = Rotation2d.exp(r.nextDouble())
 
-                    val distance = r.nextDouble()
+                    val ds = r.nextDouble()
 
                     val posPath = PositionPathSeqBuilder(beginPos, beginTangent, 1e-6)
-                        .forward(distance)
+                        .forward(ds)
                         .build()
                         .first()
 
                     assertEquals(beginPos.x, posPath.begin(1).value().x, 1e-6)
                     assertEquals(beginPos.y, posPath.begin(1).value().y, 1e-6)
 
-                    assertEquals(beginPos.x + distance * beginTangent.real, posPath.end(1).value().x, 1e-6)
-                    assertEquals(beginPos.y + distance * beginTangent.imag, posPath.end(1).value().y, 1e-6)
+                    assertEquals(beginPos.x + ds * beginTangent.real, posPath.end(1).value().x, 1e-6)
+                    assertEquals(beginPos.y + ds * beginTangent.imag, posPath.end(1).value().y, 1e-6)
                 }
             }
 

--- a/road-runner/core/src/test/kotlin/com/acmerobotics/roadrunner/BuildersTest.kt
+++ b/road-runner/core/src/test/kotlin/com/acmerobotics/roadrunner/BuildersTest.kt
@@ -133,6 +133,28 @@ fun chartSpline(q: QuinticSpline1d): XYChart {
 
         class BuildersTest {
             @Test
+            fun testForward() {
+                val r = Random.Default
+                repeat(100) {
+                    val beginPos = Vector2d(r.nextDouble(), r.nextDouble())
+                    val beginTangent = Rotation2d.exp(r.nextDouble())
+
+                    val distance = r.nextDouble()
+
+                    val posPath = PositionPathSeqBuilder(beginPos, beginTangent, 1e-6)
+                        .forward(distance)
+                        .build()
+                        .first()
+
+                    assertEquals(beginPos.x, posPath.begin(1).value().x, 1e-6)
+                    assertEquals(beginPos.y, posPath.begin(1).value().y, 1e-6)
+
+                    assertEquals(beginPos.x + distance * beginTangent.real, posPath.end(1).value().x, 1e-6)
+                    assertEquals(beginPos.y + distance * beginTangent.imag, posPath.end(1).value().y, 1e-6)
+                }
+            }
+
+            @Test
             fun testLineToX() {
                 val r = Random.Default
                 repeat(100) {
@@ -349,6 +371,25 @@ fun chartSpline(q: QuinticSpline1d): XYChart {
 
                 saveChart("posPathBuilder", chartPosPath(posPath))
                 saveChart("posePathBuilder", chartPosePath(posePath))
+            }
+
+            @Test
+            fun testPathBuilderForward() {
+                val posePath = PathBuilder(
+                    Pose2d(
+                        Vector2d(0.0, 0.0),
+                        Rotation2d.exp(0.0),
+                    ),
+                    1e-6,
+                )
+                    .forward(10.0)
+                    .forwardSplineHeading(10.0, PI / 2)
+                    .forwardConstantHeading(10.0)
+                    .forwardSplineHeading(10.0, 0.0)
+                    .build()
+                    .first()
+
+                saveChart("pathBuilder/forward", chartPosePathHeading(posePath))
             }
 
             @Test

--- a/road-runner/core/src/test/kotlin/com/acmerobotics/roadrunner/BuildersTest2.kt
+++ b/road-runner/core/src/test/kotlin/com/acmerobotics/roadrunner/BuildersTest2.kt
@@ -21,6 +21,24 @@ class BuildersTest2 {
         assertEquals(
             1,
             posBase
+                .forward(12.0)
+                .forward(24.0)
+                .build()
+                .size
+        )
+
+        assertEquals(
+            2,
+            posBase
+                .forward(12.0)
+                .forward(-12.0)
+                .build()
+                .size
+        )
+
+        assertEquals(
+            1,
+            posBase
                 .lineToX(12.0)
                 .lineToX(24.0)
                 .build()


### PR DESCRIPTION
Add `forward` trajectory builders which drives `distance` inches along the tangent. This can drive a set distance in any direction, unlike `lineToX` or `lineToY`.

Note that `ActionRegressionTest#testTrajectoryActionBuilder` already fails on main before this pr.