### PR TITLE
Fix Action Regression Test and add CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Road Runner CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master", "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master", "main" ]
   workflow_dispatch:
 
 defaults:
@@ -24,3 +24,12 @@ jobs:
         validate-wrappers: true
     - name: Build with Gradle
       run: ./gradlew build
+
+    - name: Store test reports
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: Test reports
+        path: |
+          **/build/reports/
+          **/build/test-results/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+defaults:
+  run:
+    working-directory: road-runner
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Road Runner CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+      with:
+        validate-wrappers: true
+    - name: Build with Gradle
+      run: ./gradlew build

--- a/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
+++ b/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
@@ -98,9 +98,9 @@ class ActionRegressionTest {
         )
 
         assertEquals(
-            "SequentialAction(initialActions=[Trajectory, ParallelAction(initialActions=[" +
+            "SequentialAction(initialActions=[Trajectory, Trajectory, ParallelAction(initialActions=[" +
                 "SequentialAction(initialActions=" +
-                "[Trajectory, Trajectory]), SequentialAction(initialActions=[SleepAction(dt=2.0), A])])])",
+                "[Trajectory]), SequentialAction(initialActions=[SleepAction(dt=2.0), A])])])",
             base
                 .lineToX(10.0)
                 .lineToXLinearHeading(20.0, Rotation2d.exp(1.57))
@@ -112,10 +112,10 @@ class ActionRegressionTest {
         )
 
         assertEquals(
-            "SequentialAction(initialActions=[Trajectory, ParallelAction(initialActions=[" +
+            "SequentialAction(initialActions=[Trajectory, Trajectory, ParallelAction(initialActions=[" +
                 "SequentialAction(initialActions=[" +
-                "Trajectory, Trajectory]), SequentialAction(initialActions=[SleepAction(dt=2.0), A]), " +
-                "SequentialAction(initialActions=[SleepAction(dt=3.499999999999999), B])])])",
+                "Trajectory]), SequentialAction(initialActions=[SleepAction(dt=2.0), A]), " +
+                "SequentialAction(initialActions=[SleepAction(dt=2.5000000000000004), B])])])",
             base
                 .lineToX(10.0)
                 .lineToXLinearHeading(20.0, Rotation2d.exp(1.57))
@@ -167,7 +167,7 @@ class ActionRegressionTest {
         assertEquals(
             "ParallelAction(initialActions=[SequentialAction(initialActions=[Trajectory]), " +
                 "SequentialAction(" +
-                "initialActions=[SleepAction(dt=0.4472135954999579), A])])",
+                "initialActions=[SleepAction(dt=0.316227766016838), A])])",
             base
                 .afterDisp(1.0, LabelAction("A"))
                 .lineToX(0.25)
@@ -178,7 +178,7 @@ class ActionRegressionTest {
         assertEquals(
             "ParallelAction(initialActions=[SequentialAction(initialActions=[Trajectory, " +
                 "Trajectory]), " +
-                "SequentialAction(initialActions=[SleepAction(dt=0.4472135954999579), A])])",
+                "SequentialAction(initialActions=[SleepAction(dt=0.316227766016838), A])])",
             base
                 .afterDisp(1.0, LabelAction("A"))
                 .lineToX(0.25)

--- a/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
+++ b/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
@@ -44,9 +44,8 @@ class LabelAction(private val s: String) : Action {
 }
 
 class ActionRegressionTest {
-    @Test
-    @Strictfp
-    fun testTrajectoryActionBuilder() {
+    companion object {
+        @JvmField
         val base =
             TrajectoryActionBuilder(
                 { TurnAction(it) },
@@ -58,7 +57,11 @@ class ActionRegressionTest {
                 TranslationalVelConstraint(20.0),
                 ProfileAccelConstraint(-10.0, 10.0),
             )
+    }
 
+    @Test
+    @Strictfp
+    fun testTrajectoryActionBuilder() {
         assertEquals(
             "SequentialAction(initialActions=[Trajectory])",
             base
@@ -75,7 +78,11 @@ class ActionRegressionTest {
                 .build()
                 .toString(),
         )
+    }
 
+    @Test
+    @Strictfp
+    fun testTrajectoryContinuity() {
         assertEquals(
             "SequentialAction(initialActions=[Trajectory, SleepAction(dt=10.0), Trajectory])",
             base
@@ -96,7 +103,11 @@ class ActionRegressionTest {
                 .build()
                 .toString()
         )
+    }
 
+    @Test
+    @Strictfp
+    fun testTrajectoryTimeMarkers() {
         assertEquals(
             "SequentialAction(initialActions=[Trajectory, Trajectory, ParallelAction(initialActions=[" +
                 "SequentialAction(initialActions=" +
@@ -136,7 +147,11 @@ class ActionRegressionTest {
                 .build()
                 .toString()
         )
+    }
 
+    @Test
+    @Strictfp
+    fun testTrajectoryDispMarkers() {
         assertFails {
             base
                 .afterDisp(1.0, LabelAction("A"))


### PR DESCRIPTION
This fixes the Action Regression Test that has been failing on the main branch, and splits it up into several smaller test methods.
Fixes #124.

The CI workflow is tested [here](https://github.com/kevinthegreat1/road-runner/actions/runs/13744010044) and will ensure tests pass in prs and on main. It will fail the build if tests fail.