### PR TITLE
Fix FTC Discord Invite Link

### DIFF
--- a/road-runner-docs/site/content/raw-docs/v1-0/tuning/index.md
+++ b/road-runner-docs/site/content/raw-docs/v1-0/tuning/index.md
@@ -35,7 +35,7 @@ and writing some of your own op modes before continuing.
 
 ## Getting Help
 
-Try asking the community over on the [FTC Discord](https://discord.com/invite/first-tech-challenge).
+Try asking the community over on the [FTC Discord](https://discord.com/invite/ftc).
 Many people over there have gone through the tuning process and can give the most
 practical advice for you and your team.
 


### PR DESCRIPTION
The invite link to the FTC discord [has changed](https://discord.com/channels/225450307654647808/674376698833141840/1350157648313712771). This PR updates the tuning page to use the new link.