### PR TITLE
Update road-runner-ftc Version in Docs

### DIFF
--- a/road-runner-docs/site/content/raw-docs/v1-0/installation.md
+++ b/road-runner-docs/site/content/raw-docs/v1-0/installation.md
@@ -52,7 +52,7 @@ is **not** backwards compatible.
    ```
    between the `android` and `dependencies` blocks. Also put
    ```groovy
-   implementation "com.acmerobotics.roadrunner:ftc:0.1.15"
+   implementation "com.acmerobotics.roadrunner:ftc:0.1.21"
    implementation "com.acmerobotics.roadrunner:core:1.0.1"
    implementation "com.acmerobotics.roadrunner:actions:1.0.1"
    implementation "com.acmerobotics.dashboard:dashboard:0.4.16"


### PR DESCRIPTION
Update road-runner-ftc Version in Docs, since v0.1.15 is no longer compatible with the latest quickstart.